### PR TITLE
add libwebp-dev to depend tag

### DIFF
--- a/kinetic/package.xml
+++ b/kinetic/package.xml
@@ -45,6 +45,7 @@
   <depend>libceres-dev</depend>
   <depend>libgflags-dev</depend>
   <depend>libgoogle-glog-dev</depend>
+  <depend>libwebp-dev</depend>
   <depend>lua5.2-dev</depend>
   <depend>protobuf-dev</depend>
 

--- a/lunar/package.xml
+++ b/lunar/package.xml
@@ -45,6 +45,7 @@
   <depend>libceres-dev</depend>
   <depend>libgflags-dev</depend>
   <depend>libgoogle-glog-dev</depend>
+  <depend>libwebp-dev</depend>
   <depend>lua5.2-dev</depend>
   <depend>protobuf-dev</depend>
 


### PR DESCRIPTION
we need `libwebp-dev` for 0.2.0
which has been removed for 0.3.0 (https://github.com/googlecartographer/cartographer/pull/358)
http://build.ros.org/job/Lbin_uX64__cartographer__ubuntu_xenial_amd64__binary/1/console
cc: @mikaelarguedas 

```
18:30:17 /usr/lib/ccache/x86_64-linux-gnu-g++    -isystem /usr/include/eigen3 -isystem /usr/include/lua5.2 -isystem /usr/include/cairo -isystem /usr/include/glib-2.0 -isystem /usr/lib/x86_64-linux-gnu/glib-2.0/include -isystem /usr/include/pixman-1 -isystem /usr/include/freetype2 -isystem /usr/include/libpng12 -I/tmp/binarydeb/ros-lunar-cartographer-0.2.0/obj-x86_64-linux-gnu -I/tmp/binarydeb/ros-lunar-cartographer-0.2.0 -isystem /usr/src/gmock/gtest/include  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -DNDEBUG -Wdate-time -D_FORTIFY_SOURCE=2     -pthread -std=c++11  -Wall -Wpedantic -Werror=format-security -Werror=missing-braces -Werror=reorder -Werror=return-type -Werror=switch -Werror=uninitialized -o CMakeFiles/cartographer.dir/cartographer/mapping_2d/submaps.cc.o -c /tmp/binarydeb/ros-lunar-cartographer-0.2.0/cartographer/mapping_2d/submaps.cc
18:30:20 /tmp/binarydeb/ros-lunar-cartographer-0.2.0/cartographer/mapping_2d/submaps.cc:29:25: fatal error: webp/encode.h: No such file or directory
18:30:20 compilation terminated.
18:30:20 CMakeFiles/cartographer.dir/build.make:303: recipe for target 
```