### PR TITLE
Backport find gmock fix to fix cartographer_ros builds in Lunar/Kinetic

### DIFF
--- a/kinetic/cmake/modules/FindGMock.cmake
+++ b/kinetic/cmake/modules/FindGMock.cmake
@@ -1,0 +1,75 @@
+# Copyright 2016 The Cartographer Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(NOT GMock_FOUND)
+  find_path(GMOCK_INCLUDE_DIRS gmock/gmock.h
+    HINTS
+      ENV GMOCK_DIR
+    PATH_SUFFIXES include
+    PATHS
+      /usr
+  )
+
+  # Find system-wide installed gmock.
+  find_library(GMOCK_LIBRARIES
+    NAMES gmock_main
+    HINTS
+      ENV GMOCK_DIR
+    PATH_SUFFIXES lib
+    PATHS
+      /usr
+  )
+
+  # Find system-wide gtest header.
+  find_path(GTEST_INCLUDE_DIRS gtest/gtest.h
+    HINTS
+      ENV GTEST_DIR
+    PATH_SUFFIXES include
+    PATHS
+      /usr
+  )
+  list(APPEND GMOCK_INCLUDE_DIRS ${GTEST_INCLUDE_DIRS})
+
+  if(NOT GMOCK_LIBRARIES)
+    # If no system-wide gmock found, then find src version.
+    # Ubuntu might have this.
+    find_path(GMOCK_SRC_DIR src/gmock.cc
+      HINTS
+        ENV GMOCK_DIR
+      PATHS
+        /usr/src/googletest/googlemock
+        /usr/src/gmock
+    )
+    if(GMOCK_SRC_DIR)
+      # If src version found, build it.
+      if(NOT TARGET gmock)
+        add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
+      endif()
+      # The next line is needed for Ubuntu Trusty.
+      set(GMOCK_INCLUDE_DIRS "${GMOCK_SRC_DIR}/gtest/include")
+      set(GMOCK_LIBRARIES gmock_main)
+    endif()
+  endif()
+
+  # System-wide installed gmock library might require pthreads.
+  find_package(Threads REQUIRED)
+  list(APPEND GMOCK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GMock DEFAULT_MSG GMOCK_LIBRARIES
+                                  GMOCK_INCLUDE_DIRS)
+
+# Mitigate build issue with Catkin
+set(GMOCK_FOUND FALSE)

--- a/kinetic/package.xml
+++ b/kinetic/package.xml
@@ -28,6 +28,8 @@
   </maintainer>
   <maintainer email="kei.okada@gmail.com">Kei Okada</maintainer>
   <maintainer email="ryosuke.tajima@opensource-robotics.tokyo.jp">Ryosuke Tajima</maintainer>
+  <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
+
   <license>Apache 2.0</license>
 
   <url>https://github.com/googlecartographer/cartographer</url>

--- a/lunar/cmake/modules/FindGMock.cmake
+++ b/lunar/cmake/modules/FindGMock.cmake
@@ -1,0 +1,75 @@
+# Copyright 2016 The Cartographer Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(NOT GMock_FOUND)
+  find_path(GMOCK_INCLUDE_DIRS gmock/gmock.h
+    HINTS
+      ENV GMOCK_DIR
+    PATH_SUFFIXES include
+    PATHS
+      /usr
+  )
+
+  # Find system-wide installed gmock.
+  find_library(GMOCK_LIBRARIES
+    NAMES gmock_main
+    HINTS
+      ENV GMOCK_DIR
+    PATH_SUFFIXES lib
+    PATHS
+      /usr
+  )
+
+  # Find system-wide gtest header.
+  find_path(GTEST_INCLUDE_DIRS gtest/gtest.h
+    HINTS
+      ENV GTEST_DIR
+    PATH_SUFFIXES include
+    PATHS
+      /usr
+  )
+  list(APPEND GMOCK_INCLUDE_DIRS ${GTEST_INCLUDE_DIRS})
+
+  if(NOT GMOCK_LIBRARIES)
+    # If no system-wide gmock found, then find src version.
+    # Ubuntu might have this.
+    find_path(GMOCK_SRC_DIR src/gmock.cc
+      HINTS
+        ENV GMOCK_DIR
+      PATHS
+        /usr/src/googletest/googlemock
+        /usr/src/gmock
+    )
+    if(GMOCK_SRC_DIR)
+      # If src version found, build it.
+      if(NOT TARGET gmock)
+        add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
+      endif()
+      # The next line is needed for Ubuntu Trusty.
+      set(GMOCK_INCLUDE_DIRS "${GMOCK_SRC_DIR}/gtest/include")
+      set(GMOCK_LIBRARIES gmock_main)
+    endif()
+  endif()
+
+  # System-wide installed gmock library might require pthreads.
+  find_package(Threads REQUIRED)
+  list(APPEND GMOCK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GMock DEFAULT_MSG GMOCK_LIBRARIES
+                                  GMOCK_INCLUDE_DIRS)
+
+# Mitigate build issue with Catkin
+set(GMOCK_FOUND FALSE)

--- a/lunar/package.xml
+++ b/lunar/package.xml
@@ -28,6 +28,8 @@
   </maintainer>
   <maintainer email="kei.okada@gmail.com">Kei Okada</maintainer>
   <maintainer email="ryosuke.tajima@opensource-robotics.tokyo.jp">Ryosuke Tajima</maintainer>
+  <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
+
   <license>Apache 2.0</license>
 
   <url>https://github.com/googlecartographer/cartographer</url>


### PR DESCRIPTION
Backport of https://github.com/googlecartographer/cartographer/pull/1011 to mitigate the gmock issue.
This can be removed once https://github.com/ros/catkin/pull/927 is released in kinetic and lunar.

I didnt add it to melodic yet hoping that the `catkin` fix will be released there by the time all the dependencies of `cartographer_ros` are available.

@k-okada @7675t FYI

I also added myself to the maintainer list to receive the farm's emails for all distros we release cartographer on.