### PR TITLE
add -fPIC flag to compile on more recent gcc

### DIFF
--- a/kinetic/cmake/functions.cmake
+++ b/kinetic/cmake/functions.cmake
@@ -72,7 +72,7 @@ macro(google_initialize_cartographer_project)
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
   endif()
-  set(GOOG_CXX_FLAGS "-pthread -std=c++11 ${GOOG_CXX_FLAGS}")
+  set(GOOG_CXX_FLAGS "-pthread -std=c++11 -fPIC ${GOOG_CXX_FLAGS}")
 
   google_add_flag(GOOG_CXX_FLAGS "-Wall")
   google_add_flag(GOOG_CXX_FLAGS "-Wpedantic")

--- a/lunar/cmake/functions.cmake
+++ b/lunar/cmake/functions.cmake
@@ -72,7 +72,7 @@ macro(google_initialize_cartographer_project)
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
   endif()
-  set(GOOG_CXX_FLAGS "-pthread -std=c++11 ${GOOG_CXX_FLAGS}")
+  set(GOOG_CXX_FLAGS "-pthread -std=c++11 -fPIC ${GOOG_CXX_FLAGS}")
 
   google_add_flag(GOOG_CXX_FLAGS "-Wall")
   google_add_flag(GOOG_CXX_FLAGS "-Wpedantic")


### PR DESCRIPTION
backport of https://github.com/googlecartographer/cartographer/pull/413 as its needed to build cartographer_ros on recent platforms

@k-okada @7675t FYI