### PR TITLE
disable Debian action as some dependencies are not available upstream

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -8,8 +8,9 @@ tracks:
     - git-bloom-generate -y rosrelease :{ros_distro} --source upstream -i :{release_inc}
     - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
       -i :{release_inc} --os-name ubuntu
-    - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
-      -i :{release_inc} --os-name debian --os-not-required
+    # Disable Debian as dependency libceres-dev is not available on Debian Jessie
+    # - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
+    #   -i :{release_inc} --os-name debian --os-not-required
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc}
     devel_branch: null


### PR DESCRIPTION
@k-okada sorry for having you remove these comments. This was actually a better way to handle it as bloom will complain loudly otherwise as the `libceres-dev` rosdep key doesnt exist on Debian Jessie 