### PR TITLE
prevent installation of gmock libs by using EXCLUDE_FROM_ALL

### DIFF
--- a/lunar/cmake/modules/FindGMock.cmake
+++ b/lunar/cmake/modules/FindGMock.cmake
@@ -54,7 +54,10 @@ if(NOT GMock_FOUND)
     if(GMOCK_SRC_DIR)
       # If src version found, build it.
       if(NOT TARGET gmock)
-        add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
+        add_subdirectory(${GMOCK_SRC_DIR}
+          "${CMAKE_CURRENT_BINARY_DIR}/gmock"
+          EXCLUDE_FROM_ALL
+        )
       endif()
       # The next line is needed for Ubuntu Trusty.
       set(GMOCK_INCLUDE_DIRS "${GMOCK_SRC_DIR}/gtest/include")

--- a/melodic/cmake/modules/FindGMock.cmake
+++ b/melodic/cmake/modules/FindGMock.cmake
@@ -54,10 +54,8 @@ if(NOT GMock_FOUND)
     if(GMOCK_SRC_DIR)
       # If src version found, build it.
       if(NOT TARGET gmock)
-        add_subdirectory(${GMOCK_SRC_DIR}
-          "${CMAKE_CURRENT_BINARY_DIR}/gmock"
-          EXCLUDE_FROM_ALL
-        )
+        add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock"
+          EXCLUDE_FROM_ALL)
       endif()
       # The next line is needed for Ubuntu Trusty.
       set(GMOCK_INCLUDE_DIRS "${GMOCK_SRC_DIR}/gtest/include")


### PR DESCRIPTION
replaces #10 

This backports the fix from https://github.com/googlecartographer/cartographer/pull/1047

closes #8 